### PR TITLE
Change argument order for 'task ID export'

### DIFF
--- a/src/taskwarrior.rs
+++ b/src/taskwarrior.rs
@@ -77,8 +77,8 @@ impl Task {
 
   pub fn from_id(id: u16) -> Result<Task> {
     Command::new("task")
-      .arg("export")
       .arg(id.to_string())
+      .arg("export")
       .output()
       .map(|out| {
         let mut list: Vec<Task> = serde_json::from_slice(&out.stdout).unwrap();


### PR DESCRIPTION
taskwarrior does not accept 'task export ID' anymore and returns with an error. Tested with taskwarrior v2.6.1.