### PR TITLE
Accept possibly invalid unicode from taskwarrior's export

### DIFF
--- a/src/taskwarrior.rs
+++ b/src/taskwarrior.rs
@@ -71,7 +71,7 @@ impl Task {
       .arg("export")
       .output()
       .map(|out| {
-        serde_json::from_slice(&out.stdout).unwrap()
+        serde_json::from_slice(String::from_utf8_lossy(&out.stdout).as_bytes()).unwrap()
       })
   }
 
@@ -81,7 +81,7 @@ impl Task {
       .arg("export")
       .output()
       .map(|out| {
-        let mut list: Vec<Task> = serde_json::from_slice(&out.stdout).unwrap();
+        let mut list: Vec<Task> = serde_json::from_slice(String::from_utf8_lossy(&out.stdout).as_bytes()).unwrap();
         list.remove(0)
       })
   }


### PR DESCRIPTION
rofi-taskwarrior panics on invalid unicode characters:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid unicode code point", line: 35, column: 2211)', src/taskwarrior.rs:74:45
```

`task info` does not seem to care about those at all and displays such 'broken' characters in the terminal as they were input (in my case, an import done by bugwarrior)

The lossy conversion from utf8 allows serde_json to parse the taskwarrior export, with invalid characters being replaced with �. If such a task is started, the � character will be written back into the task data via 'task import', replacing the broken character.

There may be a better way to handle this scenario without destroying the original character, but this was by far the easiest fix. ;)

